### PR TITLE
feat: add Puerto Rico (PR) to States and abbreviateState

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cobalt-int-common",
-  "version": "1.0.82",
+  "version": "1.0.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cobalt-int-common",
-      "version": "1.0.82",
+      "version": "1.0.83",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cobalt-int-common",
-  "version": "1.0.82",
+  "version": "1.0.83",
   "description": "Home for common functions and models of Cobalt Intelligence.",
   "main": "./dist/index.js",
   "publishConfig": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,6 +37,18 @@ describe('abbreviateState()', () => {
     it('should handle the districtOfColumbia abbreviated', () => {
         expect(abbreviateState('dc')).toBe(States.DC);
     });
+
+    it('should handle puertoRico camelCased', () => {
+        expect(abbreviateState('puertoRico')).toBe(States.PR);
+    });
+
+    it('should handle "Puerto Rico" with a space', () => {
+        expect(abbreviateState('Puerto Rico')).toBe(States.PR);
+    });
+
+    it('should handle Puerto Rico abbreviated', () => {
+        expect(abbreviateState('pr')).toBe(States.PR);
+    });
 });
 
 describe('formatBusinessName()', () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -406,6 +406,7 @@ export enum States {
     'OK' = "OK",
     'OR' = "OR",
     'PA' = "PA",
+    'PR' = "PR",
     'RI' = "RI",
     'SC' = "SC",
     'SD' = "SD",

--- a/src/state.ts
+++ b/src/state.ts
@@ -128,6 +128,9 @@ export function abbreviateState(stateOrAbbreviation: string): States | undefined
     else if (stateOrAbbreviation.toLocaleLowerCase() === 'pennsylvania' || stateOrAbbreviation.toLocaleLowerCase() === 'pa') {
         return States.PA;
     }
+    else if (stateOrAbbreviation.toLocaleLowerCase() === 'puertorico' || stateOrAbbreviation.toLocaleLowerCase() === 'puerto rico' || stateOrAbbreviation.toLocaleLowerCase() === 'pr') {
+        return States.PR;
+    }
     else if (stateOrAbbreviation.toLocaleLowerCase() === 'rhodeisland' || stateOrAbbreviation.toLocaleLowerCase() === 'rhode island' || stateOrAbbreviation.toLocaleLowerCase() === 'ri') {
         return States.RI;
     }


### PR DESCRIPTION
## Summary

- Adds `States.PR` and teaches `abbreviateState` to resolve `Puerto Rico`, `puertoRico`, and `pr`, with three new tests (24 pass).
- Syncs `package.json` / `package-lock.json` to **1.0.83**, which is the version already on npm. `master` still said 1.0.82, so the next `npm publish` (whose `prepublish` runs `version patch`) would have tried to republish 1.0.83 and failed. With this, the next publish lands on **1.0.84**.

## Why

Puerto Rico SOS search is deployed to dev (cobalt-intelligence/lambda-sos-search#767). Without `PR` here, `abbreviateState('Puerto Rico')` returns `undefined`, so the index skips cache reads for PR (`liveData=false` returns nothing even though cache writes work), usage rows lose their state, and error fallbacks cannot query the database. The scraper currently casts `'PR' as States` to work around it.

## After merging

1. `npm publish` from master to release 1.0.84.
2. Bump `cobalt-int-common` to `^1.0.84` in `lambda-sos-search` and drop the `'PR' as States` cast in `src/states/puertoRico/index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
